### PR TITLE
Implement flat JSONAPI for collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test_build
 docs
 .yardoc
 DIANE
+.ruby-*

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 gem 'rubocop', require: false
 gem 'simplecov', require: false
 gem 'yard', require: false
+gem 'jsonapi-parser', require: false

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'wax_tasks'
+
+namespace :wax do
+  desc 'generate JSONAPI from yaml or csv data source'
+  task :api do
+    args = ARGV.drop(1).each { |a| task a.to_sym }
+    raise WaxTasks::Error::MissingArguments, Rainbow('You must specify a collection after wax:api').magenta if args.empty?
+
+    site = WaxTasks::Site.new
+    args.each { |a| site.generate_api a }
+  end
+end

--- a/lib/wax_tasks/config.rb
+++ b/lib/wax_tasks/config.rb
@@ -49,6 +49,16 @@ module WaxTasks
 
     #
     #
+    def jsonapi_settings
+      if @config.key? 'jsonapi'
+        @config['jsonapi']
+      else
+        nil
+      end
+    end
+
+    #
+    #
     def search(name)
       search_config = @config.dig 'search', name
       raise WaxTasks::Error::InvalidConfig if search_config.nil?

--- a/lib/wax_tasks/error.rb
+++ b/lib/wax_tasks/error.rb
@@ -19,6 +19,10 @@ module WaxTasks
     class InvalidConfig < WaxTasksError; end
 
     # Custom Error:
+    # JSONAPI config cannot be found / parsed for the task at hand
+    class InvalidJSONAPIConfig < WaxTasksError; end
+
+    # Custom Error:
     # Collection specified cannot be found / parsed in site config
     class InvalidCollection < WaxTasksError; end
 

--- a/lib/wax_tasks/record.rb
+++ b/lib/wax_tasks/record.rb
@@ -79,17 +79,23 @@ module WaxTasks
         if jsonapi_settings[collection_name] && jsonapi_settings[collection_name]['meta']
           document['meta'] = jsonapi_settings[collection_name]['meta']
         end
-        document['data'] = {
-          id: @pid,
-          type: collection_name,
-          attributes: @hash,
-          links: {
-            self: "/" + path
-          }
-        }
+        document['data'] = jsonapi_object collection_name, path
         File.open(file, 'w') { |f| f.puts JSON.pretty_generate document }
         1
       end
+    end
+
+    #
+    #
+    def jsonapi_object(collection_name, path)
+      {
+        id: @pid,
+        type: collection_name,
+        attributes: @hash,
+        links: {
+          self: '/' + path
+        }
+      }
     end
   end
 end

--- a/lib/wax_tasks/record.rb
+++ b/lib/wax_tasks/record.rb
@@ -76,7 +76,9 @@ module WaxTasks
       else
         FileUtils.mkdir_p path
         document = {}
-        document['meta'] = jsonapi_settings[collection_name]['meta'] ||= nil
+        if jsonapi_settings[collection_name] && jsonapi_settings[collection_name]['meta']
+          document['meta'] = jsonapi_settings[collection_name]['meta']
+        end
         document['data'] = {
           id: @pid,
           type: collection_name,

--- a/lib/wax_tasks/record.rb
+++ b/lib/wax_tasks/record.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'json'
 
 module WaxTasks
   #
@@ -64,15 +65,27 @@ module WaxTasks
 
     #
     #
-    def write_to_api(dir)
+    def write_to_api(dir, jsonapi_settings)
       raise Error::MissingPid if @pid.nil?
 
-      path = "#{dir}/#{Utils.slug(@pid)}.md"
-      if File.exist? path
+      collection_name = @hash['collection']
+      path = "#{dir}/#{Utils.slug(@pid)}/"
+      file = path + 'index.json'
+      if File.exist? file
         0
       else
-        FileUtils.mkdir_p File.dirname(path)
-        File.open(path, 'w') { |f| f.puts "#{@hash.to_yaml}---" }
+        FileUtils.mkdir_p path
+        document = {}
+        document['meta'] = jsonapi_settings[collection_name]['meta'] ||= nil
+        document['data'] = {
+          id: @pid,
+          type: collection_name,
+          attributes: @hash,
+          links: {
+            self: "/" + path
+          }
+        }
+        File.open(file, 'w') { |f| f.puts JSON.pretty_generate document }
         1
       end
     end

--- a/lib/wax_tasks/record.rb
+++ b/lib/wax_tasks/record.rb
@@ -61,5 +61,20 @@ module WaxTasks
         1
       end
     end
+
+    #
+    #
+    def write_to_api(dir)
+      raise Error::MissingPid if @pid.nil?
+
+      path = "#{dir}/#{Utils.slug(@pid)}.md"
+      if File.exist? path
+        0
+      else
+        FileUtils.mkdir_p File.dirname(path)
+        File.open(path, 'w') { |f| f.puts "#{@hash.to_yaml}---" }
+        1
+      end
+    end
   end
 end

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -39,8 +39,10 @@ module WaxTasks
     def generate_api(name)
       result     = 0
       collection = @config.find_collection name
-      endpoint   = "api"
       raise WaxTasks::Error::InvalidCollection if collection.nil?
+      jsonapi_settings = @config.jsonapi_settings
+      raise WaxTasks::Error::InvalidJSONAPIConfig if jsonapi_settings.nil?
+      endpoint = "api"
 
       collection.records_from_metadata.each do |record|
         result += record.write_to_api("#{endpoint}/#{collection.page_source}")

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -36,6 +36,21 @@ module WaxTasks
 
     #
     #
+    def generate_api(name)
+      result     = 0
+      collection = @config.find_collection name
+      raise WaxTasks::Error::InvalidCollection if collection.nil?
+
+      # collection.records_from_metadata.each do |record|
+      #   result += record.write_to_page(collection.page_source)
+      # end
+
+      puts Rainbow("#{result} pages were generated to #{collection.page_source}.").cyan
+      puts Rainbow("\nDone ✔").green
+    end
+
+    #
+    #
     def generate_static_search(name)
       search_config = @config.search name
       index = WaxTasks::Index.new(search_config)

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -39,13 +39,14 @@ module WaxTasks
     def generate_api(name)
       result     = 0
       collection = @config.find_collection name
+      endpoint   = "api"
       raise WaxTasks::Error::InvalidCollection if collection.nil?
 
-      # collection.records_from_metadata.each do |record|
-      #   result += record.write_to_page(collection.page_source)
-      # end
+      collection.records_from_metadata.each do |record|
+        result += record.write_to_api("#{endpoint}/#{collection.page_source}")
+      end
 
-      puts Rainbow("#{result} pages were generated to #{collection.page_source}.").cyan
+      puts Rainbow("#{result} entries were generated to #{endpoint}/#{collection.page_source}.").cyan
       puts Rainbow("\nDone ✔").green
     end
 

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -42,13 +42,13 @@ module WaxTasks
       raise WaxTasks::Error::InvalidCollection if collection.nil?
       jsonapi_settings = @config.jsonapi_settings
       raise WaxTasks::Error::InvalidJSONAPIConfig if jsonapi_settings.nil?
-      endpoint = "api"
+      jsonapi_path = "#{jsonapi_settings['prefix']}/#{collection.page_source[1..-1]}"
 
       collection.records_from_metadata.each do |record|
-        result += record.write_to_api("#{endpoint}/#{collection.page_source}")
+        result += record.write_to_api(jsonapi_path, jsonapi_settings)
       end
 
-      puts Rainbow("#{result} entries were generated to #{endpoint}/#{collection.page_source}.").cyan
+      puts Rainbow("#{result} entries were generated to #{jsonapi_path}.").cyan
       puts Rainbow("\nDone ✔").green
     end
 

--- a/spec/sample_site/_config.yml
+++ b/spec/sample_site/_config.yml
@@ -50,23 +50,14 @@ search:
 jsonapi:
   prefix: 'api/v1'
   csv_collection:
-    id: 'pid'
     meta:
       copyright: '2019 someone'
       authors:
         - 'CSV Author One'
         - 'CSV Author Two'
   json_collection:
-    id: 'pid'
     meta:
       copyright: '2019 someone'
       authors:
         - 'JSON Author One'
         - 'JSON Author Two'
-  yaml_collection:
-    id: 'pid'
-    meta:
-      copyright: '2019 someone'
-      authors:
-        - 'YAML Author One'
-        - 'YAML Author Two'

--- a/spec/sample_site/_config.yml
+++ b/spec/sample_site/_config.yml
@@ -1,6 +1,6 @@
 title: 'sample site'
-url: ''
-baseurl: ''
+url: 'http://testing-example.com'
+baseurl: '/wax'
 permalink: 'pretty'
 
 collections:
@@ -47,4 +47,26 @@ search:
       page_collection:
         content: true
 
-jsonapi: ""
+jsonapi:
+  prefix: 'api/v1'
+  csv_collection:
+    id: 'pid'
+    meta:
+      copyright: '2019 someone'
+      authors:
+        - 'CSV Author One'
+        - 'CSV Author Two'
+  json_collection:
+    id: 'pid'
+    meta:
+      copyright: '2019 someone'
+      authors:
+        - 'JSON Author One'
+        - 'JSON Author Two'
+  yaml_collection:
+    id: 'pid'
+    meta:
+      copyright: '2019 someone'
+      authors:
+        - 'YAML Author One'
+        - 'YAML Author Two'

--- a/spec/sample_site/_invalid_content_config.yml
+++ b/spec/sample_site/_invalid_content_config.yml
@@ -44,3 +44,4 @@ search:
     index: js/lunr-index.json
 title: "sample site"
 url: ""
+jsonapi: ""

--- a/spec/sample_site/_invalid_format_config.yml
+++ b/spec/sample_site/_invalid_format_config.yml
@@ -1,6 +1,7 @@
 title: 'sample site'
 url: ''
 baseurl: ''
+jsonapi: ''
 
 collections:
  bad_format:

--- a/spec/sample_site/_invalid_jsonapi_config.yml
+++ b/spec/sample_site/_invalid_jsonapi_config.yml
@@ -46,5 +46,3 @@ search:
         fields: ['gambrel', 'blasphemous']
       page_collection:
         content: true
-
-jsonapi: ""

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,11 +15,13 @@ shared_context 'shared', :shared_context => :metadata do
    let(:config_from_file)         { WaxTasks.config_from_file }
    let(:invalid_content_config)   { WaxTasks.config_from_file("#{BUILD}/_invalid_content_config.yml") }
    let(:invalid_format_config)    { WaxTasks.config_from_file("#{BUILD}/_invalid_format_config.yml") }
+   let(:invalid_jsonapi_config)   { WaxTasks.config_from_file("#{BUILD}/_invalid_jsonapi_config.yml") }
    let(:empty_config)             { Hash.new }
 
    let(:site_from_config_file)    { WaxTasks::Site.new(config_from_file) }
    let(:site_from_empty_config)   { WaxTasks::Site.new(empty_config) }
    let(:site_from_invalid_config) { WaxTasks::Site.new(invalid_content_config) }
+   let(:site_from_invalid_jsonapi_config) { WaxTasks::Site.new(invalid_jsonapi_config) }
 
    let(:args_from_file)           { %w[csv_collection json_collection yaml_collection] }
    let(:csv)                      { args_from_file.first }

--- a/spec/wax_tasks/site-api_spec.rb
+++ b/spec/wax_tasks/site-api_spec.rb
@@ -97,8 +97,10 @@ describe WaxTasks::Site do
       end
     end
 
-    context 'when there is missing api-specific metadata in _config.yml' do
-      it 'raises WaxTasks::Error::WaxTasks::Error::MissingAPIMetadata'
+    context 'when there is invalid api-specific metadata in _config.yml' do
+      it 'raises WaxTasks::Error::InvalidJSONAPIConfig' do
+        expect { quiet_stdout { site_from_invalid_jsonapi_config.generate_api(csv) } }.to raise_error(WaxTasks::Error::InvalidJSONAPIConfig)
+      end
     end
   end
 

--- a/spec/wax_tasks/site-api_spec.rb
+++ b/spec/wax_tasks/site-api_spec.rb
@@ -38,6 +38,11 @@ describe WaxTasks::Site do
         expect(JSON.parse(File.read(pages[0]))['meta']).to eql({ "copyright" => "2019 someone", "authors" => ["CSV Author One", "CSV Author Two"]})
       end
 
+      it 'produces an array of objects representing the collection as a whole' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        expect(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{csv}/index.json"))['data'].length).to eql 4
+      end
+
     end
 
     context 'when given name of a valid json collection' do
@@ -61,6 +66,11 @@ describe WaxTasks::Site do
         jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
         pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{json}/*/index.json")
         expect(JSON.parse(File.read(pages[0]))['meta']).to eql({ "copyright" => "2019 someone", "authors" => ["JSON Author One", "JSON Author Two"]})
+      end
+
+      it 'produces an array of objects representing the collection as a whole' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        expect(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{json}/index.json"))['data'].length).to eql 4
       end
 
     end
@@ -88,6 +98,10 @@ describe WaxTasks::Site do
         expect(JSON.parse(File.read(pages[0]))['meta']).to be nil
       end
 
+      it 'produces an array of objects representing the collection as a whole' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        expect(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{yaml}/index.json"))['data'].length).to eql 4
+      end
 
     end
 

--- a/spec/wax_tasks/site-api_spec.rb
+++ b/spec/wax_tasks/site-api_spec.rb
@@ -43,6 +43,11 @@ describe WaxTasks::Site do
         expect(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{csv}/index.json"))['data'].length).to eql 4
       end
 
+      it 'produces an array that is valid JSONAPI' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        expect { JSONAPI.parse_response!(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{csv}/index.json"))) }.to_not raise_error
+      end
+
     end
 
     context 'when given name of a valid json collection' do
@@ -73,6 +78,11 @@ describe WaxTasks::Site do
         expect(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{json}/index.json"))['data'].length).to eql 4
       end
 
+      it 'produces an array that is valid JSONAPI' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        expect { JSONAPI.parse_response!(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{json}/index.json"))) }.to_not raise_error
+      end
+
     end
 
     context 'when given name of a valid yaml collection' do
@@ -101,6 +111,11 @@ describe WaxTasks::Site do
       it 'produces an array of objects representing the collection as a whole' do
         jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
         expect(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{yaml}/index.json"))['data'].length).to eql 4
+      end
+
+      it 'produces an array that is valid JSONAPI' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        expect { JSONAPI.parse_response!(JSON.parse(File.read("#{BUILD}/#{jsonapi_config['prefix']}/#{yaml}/index.json"))) }.to_not raise_error
       end
 
     end

--- a/spec/wax_tasks/site-api_spec.rb
+++ b/spec/wax_tasks/site-api_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'jsonapi/parser'
+
 describe WaxTasks::Site do
   include_context 'shared'
 
@@ -18,11 +20,18 @@ describe WaxTasks::Site do
         expect { quiet_stdout { site_from_config_file.generate_api(csv) } }.not_to raise_error
       end
 
-      it 'generates correct pages'
+      it 'generates the correct number of pages' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{csv}/*/index.json")
+        expect(pages.length).to eq 4
+      end
 
-      it 'produces a valid JSONAPI instance'
+      it 'produces a valid JSONAPI page' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{csv}/*/index.json")
+        expect { JSONAPI.parse_response!(JSON.parse(File.read(pages[0]))) }.to_not raise_error
+      end
 
-      it 'reports that 4 json objects were generated to the api'
     end
 
     context 'when given name of a valid json collection' do
@@ -30,11 +39,18 @@ describe WaxTasks::Site do
         expect { quiet_stdout { site_from_config_file.generate_api(json) } }.not_to raise_error
       end
 
-      it 'generates correct pages'
+      it 'generates the correct number of pages' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{json}/*/index.json")
+        expect(pages.length).to eq 4
+      end
 
-      it 'produces a valid JSONAPI instance'
+      it 'produces a valid JSONAPI page' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{json}/*/index.json")
+        expect { JSONAPI.parse_response!(JSON.parse(File.read(pages[0]))) }.to_not raise_error
+      end
 
-      it 'reports that 4 json objects were generated to the api'
     end
 
     context 'when given name of a valid yaml collection' do
@@ -42,11 +58,18 @@ describe WaxTasks::Site do
         expect { quiet_stdout { site_from_config_file.generate_api(yaml) } }.not_to raise_error
       end
 
-      it 'generates correct pages' 
+      it 'generates the correct number of pages' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{yaml}/*/index.json")
+        expect(pages.length).to eq 4
+      end
 
-      it 'produces a valid JSONAPI instance'
+      it 'produces a valid JSONAPI page' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{yaml}/*/index.json")
+        expect { JSONAPI.parse_response!(JSON.parse(File.read(pages[0]))) }.to_not raise_error
+      end
 
-      it 'reports that 4 json objects were generated to the api'
     end
 
     context 'when given the name of a non-existing collection' do

--- a/spec/wax_tasks/site-api_spec.rb
+++ b/spec/wax_tasks/site-api_spec.rb
@@ -32,6 +32,12 @@ describe WaxTasks::Site do
         expect { JSONAPI.parse_response!(JSON.parse(File.read(pages[0]))) }.to_not raise_error
       end
 
+      it 'produces a page with a meta object' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{csv}/*/index.json")
+        expect(JSON.parse(File.read(pages[0]))['meta']).to eql({ "copyright" => "2019 someone", "authors" => ["CSV Author One", "CSV Author Two"]})
+      end
+
     end
 
     context 'when given name of a valid json collection' do
@@ -49,6 +55,12 @@ describe WaxTasks::Site do
         jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
         pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{json}/*/index.json")
         expect { JSONAPI.parse_response!(JSON.parse(File.read(pages[0]))) }.to_not raise_error
+      end
+
+      it 'produces a page with a meta object' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{json}/*/index.json")
+        expect(JSON.parse(File.read(pages[0]))['meta']).to eql({ "copyright" => "2019 someone", "authors" => ["JSON Author One", "JSON Author Two"]})
       end
 
     end
@@ -69,6 +81,13 @@ describe WaxTasks::Site do
         pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{yaml}/*/index.json")
         expect { JSONAPI.parse_response!(JSON.parse(File.read(pages[0]))) }.to_not raise_error
       end
+
+      it 'produces a page without a meta object' do
+        jsonapi_config = WaxTasks::Site.new(config_from_file).config.jsonapi_settings
+        pages = Dir.glob("#{BUILD}/#{jsonapi_config['prefix']}/#{yaml}/*/index.json")
+        expect(JSON.parse(File.read(pages[0]))['meta']).to be nil
+      end
+
 
     end
 

--- a/spec/wax_tasks/site-api_spec.rb
+++ b/spec/wax_tasks/site-api_spec.rb
@@ -17,6 +17,88 @@ describe WaxTasks::Site do
       it 'runs without errors' do
         expect { quiet_stdout { site_from_config_file.generate_api(csv) } }.not_to raise_error
       end
+
+      it 'generates correct pages'
+
+      it 'produces a valid JSONAPI instance'
+
+      it 'reports that 4 json objects were generated to the api'
+    end
+
+    context 'when given name of a valid json collection' do
+      it 'runs without errors' do
+        expect { quiet_stdout { site_from_config_file.generate_api(json) } }.not_to raise_error
+      end
+
+      it 'generates correct pages'
+
+      it 'produces a valid JSONAPI instance'
+
+      it 'reports that 4 json objects were generated to the api'
+    end
+
+    context 'when given name of a valid yaml collection' do
+      it 'runs without errors' do
+        expect { quiet_stdout { site_from_config_file.generate_api(yaml) } }.not_to raise_error
+      end
+
+      it 'generates correct pages' 
+
+      it 'produces a valid JSONAPI instance'
+
+      it 'reports that 4 json objects were generated to the api'
+    end
+
+    context 'when given the name of a non-existing collection' do
+      it 'raises WaxTasks::Error::InvalidCollection' do
+        expect { quiet_stdout { site_from_config_file.generate_api('not_a_collection') } }.to raise_error(WaxTasks::Error::InvalidCollection)
+      end
+    end
+
+    context 'when given an invalid metadata file format (.xls)' do
+      it 'raises WaxTasks::Error::InvalidSource' do
+        expect { quiet_stdout { site_from_invalid_config.generate_api('xls_collection') } }.to raise_error(WaxTasks::Error::InvalidSource)
+      end
+    end
+
+    context 'when given path to a metadata file that doesnt exist' do
+      it 'raises WaxTasks::Error::MissingSource' do
+        expect { quiet_stdout { site_from_invalid_config.generate_api('missing_source_collection') } }.to raise_error(WaxTasks::Error::MissingSource)
+      end
+    end
+
+    context 'when given an invalid csv as a metadata file' do
+      it 'raises WaxTasks::Error::InvalidCSV' do
+        expect { quiet_stdout { site_from_invalid_config.generate_api('invalid_csv_collection') } }.to raise_error(WaxTasks::Error::InvalidCSV)
+      end
+    end
+
+    context 'when given an invalid json as a metadata file' do
+      it 'raises WaxTasks::Error::InvalidJSON' do
+        expect { quiet_stdout { site_from_invalid_config.generate_api('invalid_json_collection') } }.to raise_error(WaxTasks::Error::InvalidJSON)
+      end
+    end
+
+    context 'when given an invalid yaml as a metadata file' do
+      it 'raises WaxTasks::Error::InvalidYAML' do
+        expect { quiet_stdout { site_from_invalid_config.generate_api('invalid_yaml_collection') } }.to raise_error(WaxTasks::Error::InvalidYAML)
+      end
+    end
+
+    context 'when given a metadata file with duplicate pid values' do
+      it 'raises WaxTasks::Error::WaxTasks::Error::NonUniquePid' do
+        expect { quiet_stdout { site_from_invalid_config.generate_api('duplicate_pid_collection') } }.to raise_error(WaxTasks::Error::NonUniquePid)
+      end
+    end
+
+    context 'when given a metadata file records missing a pid value' do
+      it 'raises WaxTasks::Error::WaxTasks::Error::MissingPid' do
+        expect { quiet_stdout { site_from_invalid_config.generate_api('missing_pid_collection') } }.to raise_error(WaxTasks::Error::MissingPid)
+      end
+    end
+
+    context 'when there is missing api-specific metadata in _config.yml' do
+      it 'raises WaxTasks::Error::WaxTasks::Error::MissingAPIMetadata'
     end
   end
 

--- a/spec/wax_tasks/site-api_spec.rb
+++ b/spec/wax_tasks/site-api_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe WaxTasks::Site do
+  include_context 'shared'
+
+  before(:all) do
+    Test.reset
+  end
+
+  #
+  # ===================================================
+  # SITE.GENERATE_API (NAME)
+  # ===================================================
+  #
+  describe '#generate_api' do
+    context 'when given name of a valid csv collection' do
+      it 'runs without errors' do
+        expect { quiet_stdout { site_from_config_file.generate_api(csv) } }.not_to raise_error
+      end
+    end
+  end
+
+end

--- a/wax_tasks.gemspec
+++ b/wax_tasks.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('../lib')
 
 Gem::Specification.new do |spec|
   spec.name          = 'wax_tasks'
-  spec.version       = '1.0.1'
+  spec.version       = '1.1.0'
   spec.authors       = ['Marii Nyrop']
   spec.email         = ['m.nyrop@columbia.edu']
   spec.license       = 'MIT'


### PR DESCRIPTION
a day one critique of wax was that it did not "have an api," and now it does. This implements a [JSONAPI](https://jsonapi.org/) R (out of CRUD) api.

It is enabled by the `:jsonapi` key in `_config.yml`, which should have as child keys:

* `:prefix`, which sets the prefix of the api endpoint (`api/v1`, say)
* the collection name, as in `:collections`, which can then take a `:meta` object corresponding to the JSONAPI [meta object](https://jsonapi.org/format/#document-meta), so, like, with copyright and author information **for the collection** included.

A test version of the config is available in `spec/sample_site/_config.yml`

Four new methods are added:

* `Config#jsonapi_settings` returns the `:jsonapi` object from the config file or `nil`.

* `Site#generate_api` builds out the jsonapi folder structure. This includes an `index.json` for each pid for each collection as well as an `index.json` for each collection that collapses all the pids into an array.

* `Record#write_to_api` builds the `index.json` file for an individual record.

* `Record#jsonapi_object` creates a JSONAPI-looking object for the record, which is used both in `Record#write_to_api` and `Site#generate_api` when building the array `index.json`.

I also added a new error, `InvalidJSONAPIConfig`, but I reckon it could be tested out more.

I don't know how to implement this in wax proper (rather, I do, but I don't feel like doing it unless/until this PR is merged in).