### PR TITLE
Sort images by path in multi-image record

### DIFF
--- a/lib/wax_tasks/item.rb
+++ b/lib/wax_tasks/item.rb
@@ -47,7 +47,7 @@ module WaxTasks
       if accepted_image_formats.include? @type
         [Asset.new(@path, @pid, @variants)]
       elsif @type == 'dir'
-        paths = Dir.glob("#{@path}/*{#{accepted_image_formats.join(',')}}")
+        paths = Dir.glob("#{@path}/*{#{accepted_image_formats.join(',')}}").sort
         paths.map { |p| Asset.new(p, @pid, @variants) }
       else
         []


### PR DESCRIPTION
In a multi-image record such as obj12 in the qatar collection, the images are gathered in file-system order (i.e. apparently random), and this becomes the basis for their display order. 

Filename order:
![filename-order](https://user-images.githubusercontent.com/272816/83337054-8d141b80-a275-11ea-9409-dd5cb7ddce78.png)

Display order:
![display-order](https://user-images.githubusercontent.com/272816/83337055-8dacb200-a275-11ea-94f8-c7cf03be3c02.png)

This change sorts the record's assets by path before they are processed, so they will be displayed in filename order.
