### PR TITLE
Fix feature: handle custom variants for IIIF derivatives from config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.4
   Exclude: ['spec/**/*', 'test_build/**/*']
-Metrics/LineLength:
+Layout/LineLength:
   IgnoredPatterns: ['raise', 'puts', 'set', 'warn', 'ÈÉÊË', 'EEEE', 'safe_join', 'spec']
 Metrics/AbcSize:
   Max: 26

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 # dev/test utilities
+gem 'bundle-audit', require: false
 gem 'diane', require: false
 gem 'rubocop', require: false
 gem 'simplecov', require: false
 gem 'yard', require: false
-gem 'bundle-audit', require: false

--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -42,11 +42,13 @@ module WaxTasks
     #
     def to_iiif_image_record(is_only, index, base_opts)
       opts = base_opts.clone
+
       opts[:is_primary]    = index.zero?
       opts[:section_label] = "Page #{index + 1}" unless is_only
       opts[:path]          = @path
       opts[:manifest_id]   = @pid
       opts[:id]            = @id
+      opts[:variants]      = @variants
 
       WaxIiif::ImageRecord.new(opts)
     end

--- a/lib/wax_tasks/collection/images.rb
+++ b/lib/wax_tasks/collection/images.rb
@@ -77,10 +77,12 @@ module WaxTasks
       #
       #
       def iiif_builder(dir)
+        puts image_variants
         build_opts = {
           base_url: "{{ '/' | absolute_url }}#{dir}",
           output_dir: dir,
-          collection_label: @name
+          collection_label: @name,
+          variants: image_variants
         }
         WaxIiif::Builder.new(build_opts)
       end

--- a/spec/wax_tasks/site_spec.rb
+++ b/spec/wax_tasks/site_spec.rb
@@ -11,7 +11,7 @@ describe WaxTasks::Site do
   # ===================================================
   # SITE.NEW (CONFIG)
   # ===================================================
-  #
+
   describe '#new' do
     context 'when initialized with valid config hash from file' do
       it 'runs without errors' do
@@ -241,6 +241,11 @@ describe WaxTasks::Site do
   end
 
   describe '#generate_derivatives type=iiif' do
+    let(:dir) { "#{BUILD}/img/derivatives/iiif/images" }
+    let(:item) { 'img_item_1' }
+    let(:defaults) { %w[250 1140] }
+    let(:custom) { %w[50 1400] }
+
     context 'with iiif config vars' do
       it 'runs without errors' do
         expect { quiet_stdout { site_from_config_file.generate_derivatives(yaml, 'iiif') } }.not_to raise_error
@@ -250,6 +255,20 @@ describe WaxTasks::Site do
     context 'without iiif config vars' do
       it 'runs without errors' do
         expect { quiet_stdout { site_from_config_file.generate_derivatives(json, 'iiif') } }.not_to raise_error
+      end
+    end
+
+    context 'when given valid custom variants widths' do
+      it 'runs without errors' do
+        expect { quiet_stdout { site_from_config_file.generate_derivatives(json, 'iiif') } }.not_to raise_error
+      end
+
+      it 'generates the default variants' do
+        defaults.each { |v| expect(File.exist?("#{dir}/#{item}/full/#{v},/0/default.jpg")) }
+      end
+
+      it 'generates the custom variants' do
+        custom.each { |v| expect(File.exist?("#{dir}/#{item}/full/#{v},/0/default.jpg")) }
       end
     end
   end


### PR DESCRIPTION
+ addresses #48; should now properly hand off variants config to `WaxIiif::Builder`
+ need to better handle warnings for custom variants that are larger than original images*, then I'll merge to master + release

> ** e.g., if config requests a `1400` variant when original image is only `1200px` wide, wax_tasks should gracefully decline the request and warn users with colorized stdout that the variant could not be generated.