### PR TITLE
V1.0.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.4
   Exclude: ['spec/**/*', 'test_build/**/*']
-Metrics/LineLength:
+Layout/LineLength:
   IgnoredPatterns: ['raise', 'puts', 'set', 'warn', 'ÈÉÊË', 'EEEE', 'safe_join', 'spec']
 Metrics/AbcSize:
   Max: 26

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_script:
   - ./cc-test-reporter before-build
 script:
   - bundle exec rubocop
+  - bundle exec bundle-audit
   - bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - tree
 env:
   global:
-    - CC_TEST_REPORTER_ID=4bff8432781049a5d67ff0f07ced7b5fc248ec37f1624b54d14daa5807b55eaf
+    - CC_TEST_REPORTER_ID=9ef8644063d4113becf719844a0f9c0f8a452f87d69a8315c6fb090123e52cc8
 before_install:
   - gem update --system
   - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'diane', require: false
 gem 'rubocop', require: false
 gem 'simplecov', require: false
 gem 'yard', require: false
+gem 'bundle-audit', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gemspec
 gem 'bundle-audit', require: false
 gem 'diane', require: false
 gem 'rubocop', require: false
-gem 'simplecov', require: false
+gem 'simplecov', '0.17.1', require: false
 gem 'yard', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 # dev/test utilities
+gem 'bundle-audit', require: false
 gem 'diane', require: false
 gem 'rubocop', require: false
 gem 'simplecov', require: false
 gem 'yard', require: false
-gem 'bundle-audit', require: false

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # wax_tasks 🐝
-[![Build Status](https://img.shields.io/travis/minicomp/wax_tasks.svg?color=96c400)](https://travis-ci.org/minicomp/wax_tasks) [![Depfu](https://badges.depfu.com/badges/6105c55b9634e74b1c27055b19bad8f0/overview.svg)](https://depfu.com/github/minicomp/wax_tasks?project_id=10548)
+[![Build Status](https://travis-ci.com/minicomp/wax_tasks.svg?branch=master)](https://travis-ci.com/minicomp/wax_tasks) [![Depfu](https://badges.depfu.com/badges/6105c55b9634e74b1c27055b19bad8f0/overview.svg)](https://depfu.com/github/minicomp/wax_tasks?project_id=10548)
 [![Gem Version](https://badge.fury.io/rb/wax_tasks.svg)](https://badge.fury.io/rb/wax_tasks)
 [![Gem Downloads](https://img.shields.io/gem/dt/wax_tasks.svg?color=046d0b)](https://badge.fury.io/rb/wax_tasks)
-[![docs](http://img.shields.io/badge/docs-rdoc.info-blue.svg?style=flat)](https://www.rubydoc.info/github/minicomp/wax_tasks/) 
+[![docs](http://img.shields.io/badge/docs-rdoc.info-blue.svg?style=flat)](https://www.rubydoc.info/github/minicomp/wax_tasks/)
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/14408e7e962b9b84ec65/maintainability)](https://codeclimate.com/github/minicomp/wax_tasks/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/14408e7e962b9b84ec65/test_coverage)](https://codeclimate.com/github/minicomp/wax_tasks/test_coverage)
@@ -153,6 +153,14 @@ Takes a local directory of images and pdf files and generates a few image deriva
 Takes a local directory of images and pdf files and generates tiles and data that work with a IIIF compliant image viewer like [OpenSeaDragon](https://openseadragon.github.io/), [Mirador](http://projectmirador.org/), or [Leaflet IIIF](https://github.com/mejackreed/Leaflet-IIIF). [Read More](#TODO).
 
 `$ bundle exec rake wax:derivatives:iiif collection-name`
+
+### wax:clobber
+
+Destroys (or "clobbers") wax-generated files, i.e., pages generated from `wax:pagemaster`, derivatives generated from `wax:derivatives`, and search indexes generated with `wax:search` so you can start from scratch.
+
+This task does *not* touch your source metadata or source image files! Instead, it simply clears a path for you to regenerate your collection materials in case you add/edit source materials.
+
+`$ bundle exec rake wax:clobber collection-name`
 
 # Contributing
 

--- a/lib/tasks/clobber.rake
+++ b/lib/tasks/clobber.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'wax_tasks'
+
+namespace :wax do
+  desc 'destroy wax-generated collection files, including pages, derivatives, and search index(es)'
+  task :clobber do
+    args = ARGV.drop(1).each { |a| task a.to_sym }
+    args.reject! { |a| a.start_with? '-' }
+
+    raise WaxTasks::Error::MissingArguments, Rainbow("You must specify a collection after 'wax:clobber'").magenta if args.empty?
+
+    site = WaxTasks::Site.new
+    args.each { |a| site.clobber a }
+  end
+end

--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -42,11 +42,13 @@ module WaxTasks
     #
     def to_iiif_image_record(is_only, index, base_opts)
       opts = base_opts.clone
+
       opts[:is_primary]    = index.zero?
       opts[:section_label] = "Page #{index + 1}" unless is_only
       opts[:path]          = @path
       opts[:manifest_id]   = @pid
       opts[:id]            = @id
+      opts[:variants]      = @variants
 
       WaxIiif::ImageRecord.new(opts)
     end

--- a/lib/wax_tasks/collection.rb
+++ b/lib/wax_tasks/collection.rb
@@ -7,23 +7,47 @@ module WaxTasks
   #
   class Collection
     attr_reader :name, :config, :ext, :search_fields,
-                :page_source, :metadata_source, :imagedata_source
+                :page_source, :metadata_source, :imagedata_source,
+                :iiif_derivative_source, :simple_derivative_source
 
     include Collection::Metadata
     include Collection::Images
 
+    IMAGE_DERIVATIVE_DIRECTORY = 'img/derivatives'
+
     #
     #
     def initialize(name, config, source, collections_dir, ext)
-      @name             = name
-      @config           = config
-      @page_extension   = ext
-      @site_source      = source
-      @page_source      = Utils.safe_join source, collections_dir, "_#{name}"
-      @metadata_source  = Utils.safe_join source, '_data', config.dig('metadata', 'source')
-      @imagedata_source = Utils.safe_join source, '_data', config.dig('images', 'source')
-      @search_fields    = %w[pid label thumbnail permalink collection]
-      @image_variants   = image_variants
+      @name                     = name
+      @config                   = config
+      @page_extension           = ext
+      @site_source              = source
+      @page_source              = Utils.safe_join source, collections_dir, "_#{@name}"
+      @metadata_source          = Utils.safe_join source, '_data', config.dig('metadata', 'source')
+      @imagedata_source         = Utils.safe_join source, '_data', config.dig('images', 'source')
+      @iiif_derivative_source   = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif', @name
+      @simple_derivative_source = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'simple', @name
+      @search_fields            = %w[pid label thumbnail permalink collection]
+      @image_variants           = image_variants
+    end
+
+    #
+    #
+    def clobber_pages
+      return unless Dir.exist? @page_source
+      puts Rainbow("Removing pages from #{@page_source}").cyan
+      FileUtils.remove_dir @page_source, true
+    end
+
+    #
+    #
+    def clobber_derivatives
+      [@iiif_derivative_source, @simple_derivative_source].each do |dir|
+        if Dir.exist? dir
+          puts Rainbow("Removing derivatives from #{dir}").cyan
+          FileUtils.remove_dir dir, true
+        end
+      end
     end
   end
 end

--- a/lib/wax_tasks/collection/images.rb
+++ b/lib/wax_tasks/collection/images.rb
@@ -54,14 +54,14 @@ module WaxTasks
 
       #
       #
-      def write_simple_derivatives(dir)
+      def write_simple_derivatives
         puts Rainbow("Generating simple image derivatives for collection '#{@name}'\nThis might take awhile.").cyan
 
         bar = ProgressBar.new(items_from_imagedata.length)
         bar.write
         items_from_imagedata.map do |item|
           item.simple_derivatives.each do |d|
-            path = "#{dir}/#{d.path}"
+            path = "#{@simple_derivative_source}/#{d.path}"
             FileUtils.mkdir_p File.dirname(path)
             next if File.exist? path
 
@@ -77,14 +77,13 @@ module WaxTasks
       #
       #
       def iiif_builder(dir)
-        puts image_variants
         build_opts = {
           base_url: "{{ '/' | absolute_url }}#{dir}",
           output_dir: dir,
           collection_label: @name,
           variants: image_variants
         }
-        WaxIiif::Builder.new(build_opts)
+        WaxIiif::Builder.new build_opts
       end
 
       #
@@ -117,10 +116,10 @@ module WaxTasks
 
       #
       #
-      def write_iiif_derivatives(dir)
+      def write_iiif_derivatives
         items     = items_from_imagedata
         iiif_data = items.map(&:iiif_image_records).flatten
-        builder   = iiif_builder(dir)
+        builder   = iiif_builder @iiif_derivative_source
 
         builder.load iiif_data
 
@@ -128,7 +127,7 @@ module WaxTasks
         builder.process_data
         records = items.map(&:record).compact
 
-        add_font_matter_to_json_files dir
+        add_font_matter_to_json_files @iiif_derivative_source
         add_iiif_results_to_records records, builder.manifests
       end
     end

--- a/lib/wax_tasks/collection/images.rb
+++ b/lib/wax_tasks/collection/images.rb
@@ -77,10 +77,12 @@ module WaxTasks
       #
       #
       def iiif_builder(dir)
+        puts image_variants
         build_opts = {
           base_url: "{{ '/' | absolute_url }}#{dir}",
           output_dir: dir,
-          collection_label: @name
+          collection_label: @name,
+          variants: image_variants
         }
         WaxIiif::Builder.new(build_opts)
       end

--- a/lib/wax_tasks/config.rb
+++ b/lib/wax_tasks/config.rb
@@ -6,8 +6,12 @@ module WaxTasks
     attr_reader :collections
 
     def initialize(config)
-      @config           = config
-      @collections      = process_collections
+      @config         = config
+      @collections    = process_collections
+    end
+
+    def self
+      @config
     end
 
     #

--- a/lib/wax_tasks/index.rb
+++ b/lib/wax_tasks/index.rb
@@ -34,7 +34,7 @@ module WaxTasks
     #
     #
     def write_to(dir)
-      file_path = WaxTasks::Utils.safe_join Dir.pwd, dir, path
+      file_path = WaxTasks::Utils.safe_join dir, @path
       FileUtils.mkdir_p File.dirname(file_path)
       File.open(file_path, 'w') do |f|
         f.puts "---\nlayout: none\n---\n"

--- a/lib/wax_tasks/utils.rb
+++ b/lib/wax_tasks/utils.rb
@@ -114,7 +114,7 @@ module WaxTasks
     #
     #
     def self.safe_join(*args)
-      File.join(args.compact)
+      File.join(args.compact).sub %r{^\/}, ''
     end
 
     # Constructs the order variable for each page (if the collection

--- a/spec/wax_tasks/site_spec.rb
+++ b/spec/wax_tasks/site_spec.rb
@@ -11,7 +11,7 @@ describe WaxTasks::Site do
   # ===================================================
   # SITE.NEW (CONFIG)
   # ===================================================
-  #
+
   describe '#new' do
     context 'when initialized with valid config hash from file' do
       it 'runs without errors' do
@@ -241,6 +241,11 @@ describe WaxTasks::Site do
   end
 
   describe '#generate_derivatives type=iiif' do
+    let(:dir) { "#{BUILD}/img/derivatives/iiif/images" }
+    let(:item) { 'img_item_1' }
+    let(:defaults) { %w[250 1140] }
+    let(:custom) { %w[50 1400] }
+
     context 'with iiif config vars' do
       it 'runs without errors' do
         expect { quiet_stdout { site_from_config_file.generate_derivatives(yaml, 'iiif') } }.not_to raise_error
@@ -250,6 +255,20 @@ describe WaxTasks::Site do
     context 'without iiif config vars' do
       it 'runs without errors' do
         expect { quiet_stdout { site_from_config_file.generate_derivatives(json, 'iiif') } }.not_to raise_error
+      end
+    end
+
+    context 'when given valid custom variants widths' do
+      it 'runs without errors' do
+        expect { quiet_stdout { site_from_config_file.generate_derivatives(json, 'iiif') } }.not_to raise_error
+      end
+
+      it 'generates the default variants' do
+        defaults.each { |v| expect(File.exist?("#{dir}/#{item}/full/#{v},/0/default.jpg")) }
+      end
+
+      it 'generates the custom variants' do
+        custom.each { |v| expect(File.exist?("#{dir}/#{item}/full/#{v},/0/default.jpg")) }
       end
     end
   end

--- a/wax_tasks.gemspec
+++ b/wax_tasks.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'wax_tasks'
   spec.version       = '1.0.3'
   spec.authors       = ['Marii Nyrop']
-  spec.email         = ['m.nyrop@columbia.edu']
+  spec.email         = ['marii@nyu.edu']
   spec.license       = 'MIT'
   spec.homepage      = 'https://github.com/minicomp/wax_tasks'
   spec.summary       = 'Rake tasks for minimal exhibition sites with Jekyll Wax.'


### PR DESCRIPTION
- Resolves #46 and adds `wax:clobber` task (h/t @andrewbattista)
- Resolves #48 to handle IIIF custom variants (h/t @pbinkley)
- Fixes [code coverage reporting](https://codeclimate.com/github/minicomp/wax_tasks)
- Makes `Utils.safe_join` safer by stripping starting slashes in paths

**Note:**  
In order to scope `wax:clobber`, image derivative paths have been scoped to their collection names. (i.e., they live in `derivatives/iiif/{collection-name}` instead of `derivatives/iiif`.) This has the additional benefit of allowing non-unique `pid` values *across* collections. (i.e., `collection1/itemA` and `collection2/itemA` are now acceptable)