### PR TITLE
fix "full" variant bug

### DIFF
--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -3,21 +3,24 @@
 #
 module WaxTasks
   Derivative = Struct.new(:path, :label, :img)
-  attr_reader :id, :path
 
   #
   class Asset
+    attr_reader :id, :path
+
+    DEFAULT_VARIANTS = { 'thumbnail' => 250, 'full' => 1140 }.freeze
+
     def initialize(path, pid, variants)
       @path     = path
       @pid      = pid
       @id       = asset_id
-      @variants = variants
+      @variants = DEFAULT_VARIANTS.merge variants
     end
 
     #
     #
     def asset_id
-      id = File.basename(@path, '.*')
+      id = File.basename @path, '.*'
       id.prepend "#{@pid}_" unless id == @pid
       id
     end
@@ -26,7 +29,7 @@ module WaxTasks
     #
     def simple_derivatives
       @variants.map do |label, width|
-        img = MiniMagick::Image.open(@path)
+        img = MiniMagick::Image.open @path
         if width > img.width
           warn Rainbow("Tried to create derivative #{width}px wide, but asset #{@id} for item #{@pid} only has a width of #{img.width}px.").yellow
         else

--- a/lib/wax_tasks/collection.rb
+++ b/lib/wax_tasks/collection.rb
@@ -28,7 +28,7 @@ module WaxTasks
       @iiif_derivative_source   = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif', @name
       @simple_derivative_source = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'simple', @name
       @search_fields            = %w[pid label thumbnail permalink collection]
-      @image_variants           = image_variants
+      @image_variants           = @config.dig('images', 'variants') || {}
     end
 
     #

--- a/lib/wax_tasks/collection/images.rb
+++ b/lib/wax_tasks/collection/images.rb
@@ -12,14 +12,6 @@ module WaxTasks
     module Images
       #
       #
-      def image_variants
-        default_variants = { 'thumbnail' => 250, 'full' => 1140 }
-        custom_variants  = @config.dig('images', 'variants') || {}
-        default_variants.merge custom_variants
-      end
-
-      #
-      #
       def items_from_imagedata
         raise Error::MissingSource, "Cannot find image data source '#{@imagedata_source}'" unless Dir.exist? @imagedata_source
 
@@ -81,7 +73,7 @@ module WaxTasks
           base_url: "{{ '/' | absolute_url }}#{dir}",
           output_dir: dir,
           collection_label: @name,
-          variants: image_variants
+          variants: @image_variants.dup.tap { |h| h.delete 'full' }
         }
         WaxIiif::Builder.new build_opts
       end

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -30,8 +30,9 @@ module WaxTasks
       @config.self.dig('search').each do |_name, search|
         next unless search.key? 'index'
         index = Utils.safe_join @config.source, search['index']
+        next unless File.exist? index
         puts Rainbow("Removing search index #{index}").cyan
-        FileUtils.rm index if File.exist? index
+        FileUtils.rm index
       end
 
       puts Rainbow("\nDone ✔").green

--- a/wax_tasks.gemspec
+++ b/wax_tasks.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.email         = ['marii@nyu.edu']
   spec.license       = 'MIT'
   spec.homepage      = 'https://github.com/minicomp/wax_tasks'
-  spec.summary       = 'Rake tasks for minimal exhibition sites with Jekyll Wax.'
-  spec.description   = 'Rake tasks for minimal exhibition sites with Jekyll Wax.'
+  spec.summary       = 'Rake tasks for minimal exhibition sites with Minicomp/Wax.'
+  spec.description   = 'Rake tasks for minimal exhibition sites with Minicomp/Wax.'
 
   spec.files                  = Dir['Gemfile', 'lib/**/*']
   spec.test_files             = Dir['spec/*']
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
   spec.add_runtime_dependency 'rake', '~> 13.0'
   spec.add_runtime_dependency 'safe_yaml', '~> 1.0'
-  spec.add_runtime_dependency 'wax_iiif', '>= 0.1.2', '< 0.3'
+  spec.add_runtime_dependency 'wax_iiif', '~> 0.2'
 
   spec.add_development_dependency 'rspec', '~> 3'
 end


### PR DESCRIPTION
WaxIiif (and IiifS3) rely on an image variant with key `full` to store the true "full size" width an height; therefore, `full` must be a disallowed custom variant key in Wax or it will slice image tiles based on the arbitrary variant and **not** the full source image.

This patch drops any custom IIIF variant named `full` before passing it to the `WaxIiif::Builder`. 

The `wax:derivatives:simple` task will still create a variants for `full` (default `1140w`), which *can* be overridden. 

This behavior should be documented in the [wiki](https://minicomp.github.io/wiki/wax/) ASAP and, in future iterations, `wax_theme` should use another derivative keyword (e.g., `banner` or `hero` instead of `full`)
