### PR TITLE
make clobber more brutish, avoid breaking change w img paths

### DIFF
--- a/lib/wax_tasks/collection.rb
+++ b/lib/wax_tasks/collection.rb
@@ -25,8 +25,8 @@ module WaxTasks
       @page_source              = Utils.safe_join source, collections_dir, "_#{@name}"
       @metadata_source          = Utils.safe_join source, '_data', config.dig('metadata', 'source')
       @imagedata_source         = Utils.safe_join source, '_data', config.dig('images', 'source')
-      @iiif_derivative_source   = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif', @name
-      @simple_derivative_source = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'simple', @name
+      @iiif_derivative_source   = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif'
+      @simple_derivative_source = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'simple'
       @search_fields            = %w[pid label thumbnail permalink collection]
       @image_variants           = @config.dig('images', 'variants') || {}
     end


### PR DESCRIPTION
current (non-released) implementation of `wax:clobber` tries to be too smart, it namespaces image derivatives to the collection so that clobbering can be collection-specific. this created a breaking change for where img resources are generated, so that feature is being tabled until a major release. 

this PR makes `clobber` brutish again; docs should reflect that