### PR TITLE
more verbose error msg for MissingPid

### DIFF
--- a/lib/wax_tasks/utils.rb
+++ b/lib/wax_tasks/utils.rb
@@ -27,7 +27,7 @@ module WaxTasks
     # @return [Array] same data unless a an item is missing the key `pid`
     # @raise WaxTasks::Error::MissingPid
     def self.assert_pids(data)
-      data.each_with_index { |d, i| raise Error::MissingPid, "Collection is missing pid for item #{i}." unless d.key? 'pid' }
+      data.each_with_index { |d, i| raise Error::MissingPid, "Collection is missing pid for item #{i}.\nHint: review common .csv formatting issues (such as hidden characters) in the documentation: https://minicomp.github.io/wiki/wax/preparing-your-collection-data/metadata/" unless d.key? 'pid' }
       data
     end
 


### PR DESCRIPTION
As per [wax#82](https://github.com/minicomp/wax/issues/82) a tiny edit to add "hint" language for MissingPid errors. Tested locally:

![pid_error_lg](https://user-images.githubusercontent.com/12399460/91649764-59e45280-ea45-11ea-9c4c-267b71289d4c.jpg)
