### PR TITLE
ensure default variants are added to metadata for theme use

### DIFF
--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -8,13 +8,13 @@ module WaxTasks
   class Asset
     attr_reader :id, :path
 
-    DEFAULT_VARIANTS = { 'thumbnail' => 250, 'full' => 1140 }.freeze
+
 
     def initialize(path, pid, variants)
       @path     = path
       @pid      = pid
       @id       = asset_id
-      @variants = DEFAULT_VARIANTS.merge variants
+      @variants = variants
     end
 
     #

--- a/lib/wax_tasks/collection.rb
+++ b/lib/wax_tasks/collection.rb
@@ -14,6 +14,7 @@ module WaxTasks
     include Collection::Images
 
     IMAGE_DERIVATIVE_DIRECTORY = 'img/derivatives'
+    DEFAULT_VARIANTS = { 'thumbnail' => 250, 'fullwidth' => 1140 }.freeze
 
     #
     #
@@ -28,7 +29,14 @@ module WaxTasks
       @iiif_derivative_source   = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif'
       @simple_derivative_source = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'simple'
       @search_fields            = %w[pid label thumbnail permalink collection]
-      @image_variants           = @config.dig('images', 'variants') || {}
+      @image_variants           = image_variants
+    end
+
+    #
+    #
+    def image_variants
+      vars = @config.dig('images', 'variants') || {}
+      DEFAULT_VARIANTS.merge vars
     end
 
     #

--- a/lib/wax_tasks/collection/metadata.rb
+++ b/lib/wax_tasks/collection/metadata.rb
@@ -68,7 +68,7 @@ module WaxTasks
         lost_record_pids.each do |pid|
           new << original.find { |r| r.pid == pid }
         end
-        new.sort_by(&:order)
+        new
       end
 
       #

--- a/lib/wax_tasks/record.rb
+++ b/lib/wax_tasks/record.rb
@@ -23,9 +23,13 @@ module WaxTasks
       @hash.keys
     end
 
-    #
+    # PATCH :: rename 'fullwidth' to 'full' to
+    # (1) avoid breaking wax_iiif with special 'full' variant label
+    # (2) avoid breaking wax_theme which still expects 'full' to provide an image path
+    # this can be deprecated when a new version of wax_theme looks for another fullsize key
     #
     def set(key, value)
+      key = 'full' if key == 'fullwidth'
       @hash[key] = value
     end
 


### PR DESCRIPTION
- new variants feature cannot use keyword `full` because `wax_iiif` uses `full` for the *true* full size (for tile slicing and etc.)
- however, `wax_theme` expects a (web) `full` derivative for banner images and etc.
- this patch temporarily sets `1140` as `fullwidth` variant for `wax_iiif` but renames it to `full` before passing off to `wax_theme` via metadata file

future versions of `wax_theme` should use a value other than `full`; then this behavior in `wax_tasks` can be deprecated.