### PR TITLE
Add annotation lists (WIP, do not merge)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,13 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'addressable'
+
 # dev/test utilities
 gem 'bundle-audit', require: false
+gem 'byebug', require: false
 gem 'diane', require: false
+gem 'nokogiri', require: false
 gem 'rubocop', require: false
 gem 'simplecov', '0.17.1', require: false
 gem 'yard', require: false

--- a/lib/tasks/annotations.rake
+++ b/lib/tasks/annotations.rake
@@ -13,4 +13,27 @@ namespace :wax do
     site = WaxTasks::Site.new
     args.each { |a| site.generate_annotations(a) }
   end
+
+  task :updatemanifest do
+    args = ARGV.drop(1).each { |a| task a.to_sym }
+    args.reject! { |a| a.start_with? '-' }
+
+    raise WaxTasks::Error::MissingArguments, Rainbow("You must specify a collection after 'wax:updatemanifest'").magenta if args.empty?
+
+    site = WaxTasks::Site.new
+    args.each do |collection_name| 
+      collection = site.collections.find { |c| c.name == collection_name }
+      annotationdata_source = collection.annotationdata_source
+  
+      annotationlists = Dir.glob("#{annotationdata_source}/**/*.{yaml,yml,json}").sort
+
+      byebug
+
+        # dir: img/derivatives/iiif/annotation
+        # annotationlist: <WaxTasks::AnnotationList>
+        # path: img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json
+
+      site.add_annotationlist_to_manfest(dir, annotationlists, path)
+    end
+  end
 end

--- a/lib/tasks/annotations.rake
+++ b/lib/tasks/annotations.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'wax_tasks'
+
+namespace :wax do
+  desc 'generate annotationlists from local yaml files'
+  task :annotations do
+    args = ARGV.drop(1).each { |a| task a.to_sym }
+    args.reject! { |a| a.start_with? '-' }
+
+    raise WaxTasks::Error::MissingArguments, Rainbow("You must specify a collection after 'wax:annotations'").magenta if args.empty?
+
+    site = WaxTasks::Site.new
+    args.each { |a| site.generate_annotations(a) }
+  end
+end

--- a/lib/tasks/annotations.rake
+++ b/lib/tasks/annotations.rake
@@ -3,7 +3,7 @@
 require 'wax_tasks'
 
 namespace :wax do
-  desc 'generate annotationlists from local yaml files'
+  desc 'generate annotationlists from local yaml/json files'
   task :annotations do
     args = ARGV.drop(1).each { |a| task a.to_sym }
     args.reject! { |a| a.start_with? '-' }
@@ -21,19 +21,17 @@ namespace :wax do
     raise WaxTasks::Error::MissingArguments, Rainbow("You must specify a collection after 'wax:updatemanifest'").magenta if args.empty?
 
     site = WaxTasks::Site.new
+    config = WaxTasks.config_from_file
+
+    dir = 'img/derivatives/iiif/annotation'
+
     args.each do |collection_name| 
       collection = site.collections.find { |c| c.name == collection_name }
       annotationdata_source = collection.annotationdata_source
   
-      annotationlists = Dir.glob("#{annotationdata_source}/**/*.{yaml,yml,json}").sort
-
-      byebug
-
-        # dir: img/derivatives/iiif/annotation
-        # annotationlist: <WaxTasks::AnnotationList>
-        # path: img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json
-
-      site.add_annotationlist_to_manfest(dir, annotationlists, path)
+      collection.add_annotationlists_to_manifest(
+        Dir.glob("#{annotationdata_source}/**/*.{yaml,yml,json}").sort
+      )
     end
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -2,8 +2,6 @@
 
 require_relative './import/hocr.rb'
 
-require 'byebug'
-
 namespace :wax do
   namespace :import do
     task :hocr, [:hocr_path, :collection, :canvas, :granularity] do |_t, args|

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative './import/hocr.rb'
+
+require 'byebug'
+
+namespace :wax do
+  namespace :import do
+    task :hocr, [:hocr_path, :collection, :canvas, :granularity] do |_t, args|
+      desc 'generate canvas-level annotationlist yaml file from hocr file'
+
+      # TODO: validate args
+
+      hocr_annotations = WaxTasks::HocrOpenAnnotationCreator.new(args)
+      hocr_annotations.save
+
+      puts 'done'
+    end
+  end
+end

--- a/lib/tasks/import/hocr.rb
+++ b/lib/tasks/import/hocr.rb
@@ -123,7 +123,7 @@ img/derivatives/iiif/canvas/\
     yaml_list = {
       'uri' => @list_uri,
       'collection' => @collection,
-      'id' => @identifier,
+      'canvas' => @identifier,
       'label' => @label,
       'target' => @canvas_uri,
       'resources' => []

--- a/lib/tasks/import/hocr.rb
+++ b/lib/tasks/import/hocr.rb
@@ -3,8 +3,6 @@ require 'json'
 require 'nokogiri'
 require 'yaml'
 
-require 'byebug'
-
 # adapted from Okracoke:
 # https://github.com/NCSU-Libraries/ocracoke/blob/master/app/processing_helpers/hocr_open_annotation_creator.rb
 module WaxTasks

--- a/lib/tasks/import/hocr.rb
+++ b/lib/tasks/import/hocr.rb
@@ -1,0 +1,142 @@
+require 'nokogiri'
+require 'addressable/template'
+require 'json'
+require 'yaml'
+require 'byebug'
+
+# adapted from Okracoke: 
+# https://github.com/NCSU-Libraries/ocracoke/blob/master/app/processing_helpers/hocr_open_annotation_creator.rb
+
+class HocrOpenAnnotationCreator
+
+  def initialize(args)
+    @canvas_uri = "{{ '/' | absolute_url }}\
+img/derivatives/iiif/canvas/\
+#{args[:collection]}_#{args[:canvas]}.json"
+
+    @hocr = File.open(args[:hocr_path]){ |f| Nokogiri::XML(f) }
+    @collection = args[:collection]
+    @identifier = args[:canvas]
+    @granularity = args[:granularity]
+
+    @selector = get_selector
+  end
+
+  def manifest_canvas_on_xywh(id, xywh)
+    @canvas_uri + "#xywh=#{xywh}"
+  end
+
+  def get_selector
+    if @granularity == "word"
+     "ocrx_word"
+    elsif @granularity == "line"
+     "ocr_line"
+    elsif @granularity == "paragraph"
+      "ocr_par"
+    else
+      ""
+     end
+ end
+
+ def resources
+    @hocr.xpath(".//*[contains(@class, '#{@selector}')]").map do |chunk|
+      text = chunk.text().gsub("\n", ' ').squeeze(' ').strip
+      if !text.empty?
+        title = chunk['title']
+        title_parts = title.split('; ')
+        xywh = '0,0,0,0'
+        title_parts.each do |title_part|
+          if title_part.include?('bbox')
+            match_data = /bbox\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/.match title_part
+            x = match_data[1].to_i
+            y = match_data[2].to_i
+            x1 = match_data[3].to_i
+            y1 = match_data[4].to_i
+            w = x1 - x
+            h = y1 - y
+            xywh = "#{x},#{y},#{w},#{h}"
+          end
+        end
+        annotation(text, xywh)
+       end
+    end.compact
+  end
+
+  def annotation_list
+    {
+      :"@context" => "http://iiif.io/api/presentation/2/context.json",
+      :"@id" => annotation_list_id,
+      :"@type" => "sc:AnnotationList",
+      :"@label" => "OCR text granularity of #{@granularity}",
+      resources: resources
+    }
+  end
+
+  def annotation_list_id_base
+    "{{ '/' | absolute_url }}\
+img/derivatives/iiif/canvas/\
+#{@collection}/#{@identifier}-annotation-list-#{@granularity}.json"
+
+    #File.join OKRACOKE_BASE_URL, @identifier + '-annotation-list-' + @granularity
+  end
+
+  def annotation_list_id
+    annotation_list_id_base + '.json'
+  end
+
+  def annotation(chars, xywh)
+    {
+      :"@id" => annotation_id(xywh),
+      :"@type" => "oa:Annotation",
+      motivation: "sc:painting",
+      resource: {
+        :"@type" => "cnt:ContentAsText",
+        format: "text/plain",
+        chars: chars
+      },
+      # TODO: use canvas_url_template
+      on: on_canvas(xywh)
+    }
+  end
+
+  def annotation_id(xywh)
+    File.join annotation_list_id_base, xywh
+  end
+
+  def on_canvas(xywh)
+    manifest_canvas_on_xywh(@identifier, xywh)
+  end
+
+  def to_json
+    annotation_list.to_json
+  end
+
+  def id
+    @identifier
+  end
+
+  def to_yaml
+    yaml_list = {
+      'id' => @identifier,
+      'label' => @identifier + '-annotation-list-' + @granularity,
+      'target' => @canvas_uri,
+      'resources' => []
+    }
+    annotation_list[:resources].each do |resource|
+      yaml_list['resources'] << {
+        'xywh' => resource[:@id].sub(/.*\/(.*)/, '\1'),
+        'chars' => resource[:resource][:chars]
+      }
+    end
+    yaml_list.to_yaml
+  end
+  
+  def save
+    FileUtils.mkdir_p("./_data/annotations/#{@collection}/#{@collection}")
+    # TODO: handle item as distinct from collection
+    File.open("./_data/annotations/#{@collection}/#{@collection}/#{@collection}_#{@identifier}_ocr_#{@granularity}.yaml", 'w') do |file|
+      file.write(to_yaml)
+    end
+  end
+
+end

--- a/lib/wax_tasks.rb
+++ b/lib/wax_tasks.rb
@@ -13,6 +13,8 @@ require 'rainbow'
 require 'safe_yaml'
 
 # relative
+require_relative 'wax_tasks/annotation'
+require_relative 'wax_tasks/annotationlist'
 require_relative 'wax_tasks/asset'
 require_relative 'wax_tasks/collection'
 require_relative 'wax_tasks/config'

--- a/lib/wax_tasks/annotation.rb
+++ b/lib/wax_tasks/annotation.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+#
+class Annotation
+  def initialize(annotationlist_id, canvas_id, xywh,
+                 resource = {}, options = {})
+    @annotationlist_id = annotationlist_id
+    @canvas_id    = canvas_id
+    @xywh         = xywh            # TODO: validate xywh
+    @type         = 'oa:Annotation'
+    @motivation   = options[:motivation] || 'sc:painting'
+    @resource     = 
+      {
+        :@type => resource[:type] || 'cnt:ContentAsText',
+        chars:    resource[:chars] || '',
+        format:   resource[:format] || 'text/plain'
+        # TODO: extend or subclass this as needed for other kinds of annotations
+      }
+    @resource[:language] = resource[:language] unless resource[:language].nil?
+  end
+
+  def to_hash
+    {
+      :@context => 'http://iiif.io/api/presentation/2/context.json',
+      :@id => @annotationlist_id + '#' + @xywh,
+      :@type => @type,
+      motivation: @motivation,
+      resource: @resource,
+      on: @canvas_id + '#' + @xywh
+    }
+  end
+end

--- a/lib/wax_tasks/annotationlist.rb
+++ b/lib/wax_tasks/annotationlist.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module WaxTasks
+  #
+  class AnnotationList
+    attr_reader :name
+
+    def initialize(annotation_list)
+      # input is in format of annotation list yaml
+      @name       = annotation_list['id']
+      @label      = annotation_list['label']
+      @target     = annotation_list['target']
+      @type       = 'sc:AnnotationList'
+      @resources  = annotation_list["resources"].map do |resource|
+        {
+          :@type =>     resource['type'] || 'cnt:ContentAsText',
+          chars:        resource['chars'] || '',
+          format:       resource['format'] || 'text/plain',
+          xywh:         resource['xywh'] || ''
+          # TODO: extend or subclass this as needed for other kinds of annotations
+        }
+      end
+    end
+
+    def to_json
+      {
+        :@context => 'http://iiif.io/api/presentation/2/context.json',
+        :@id => 'id placeholder',
+        :@type => @type,
+        label: @label,
+        resources: @resources.map do |resource|
+          {
+            :@id => "id placeholder/#{resource[:xywh]}",
+            :@type => 'oa:Annotation',
+            motivation: 'sc:painting',
+            resource: {
+              :@type => resource[:@type],
+              format: resource[:format],
+              chars: resource[:chars]
+            },
+            on: "#{@target}#xywh=#{resource[:xywh]}"
+          }
+        end
+      }.to_json
+    end
+
+    def save
+      path = "#{dir}/#{Utils.slug(@pid)}.md"
+      if File.exist? path
+        0
+      else
+        FileUtils.mkdir_p File.dirname(path)
+        File.open(path, 'w') { |f| f.puts "#{@hash.to_yaml}---" }
+        1
+      end
+    end
+  end
+end

--- a/lib/wax_tasks/annotationlist.rb
+++ b/lib/wax_tasks/annotationlist.rb
@@ -23,7 +23,6 @@ module WaxTasks
           # TODO: extend or subclass this as needed for other kinds of annotations
         }
       end
-      byebug
     end
 
     def to_json

--- a/lib/wax_tasks/annotationlist.rb
+++ b/lib/wax_tasks/annotationlist.rb
@@ -3,13 +3,16 @@
 module WaxTasks
   #
   class AnnotationList
-    attr_reader :name
+    attr_reader :name, :label
 
     def initialize(annotation_list)
       # input is in format of annotation list yaml
+      @uri        = annotation_list['uri']
+      @collection = annotation_list['collection']
       @name       = annotation_list['id']
       @label      = annotation_list['label']
       @target     = annotation_list['target']
+
       @type       = 'sc:AnnotationList'
       @resources  = annotation_list["resources"].map do |resource|
         {

--- a/lib/wax_tasks/annotationlist.rb
+++ b/lib/wax_tasks/annotationlist.rb
@@ -3,13 +3,13 @@
 module WaxTasks
   #
   class AnnotationList
-    attr_reader :name, :label
+    attr_reader :canvas, :label
 
     def initialize(annotation_list)
       # input is in format of annotation list yaml
       @uri        = annotation_list['uri']
       @collection = annotation_list['collection']
-      @name       = annotation_list['id']
+      @canvas       = annotation_list['canvas']
       @label      = annotation_list['label']
       @target     = annotation_list['target']
 
@@ -23,17 +23,17 @@ module WaxTasks
           # TODO: extend or subclass this as needed for other kinds of annotations
         }
       end
+      byebug
     end
 
     def to_json
       {
         :@context => 'http://iiif.io/api/presentation/2/context.json',
-        :@id => 'id placeholder',
+        :@id =>  @uri,
         :@type => @type,
         label: @label,
         resources: @resources.map do |resource|
           {
-            :@id => "id placeholder/#{resource[:xywh]}",
             :@type => 'oa:Annotation',
             motivation: 'sc:painting',
             resource: {

--- a/lib/wax_tasks/collection.rb
+++ b/lib/wax_tasks/collection.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'collection/annotations'
 require_relative 'collection/images'
 require_relative 'collection/metadata'
 
@@ -8,10 +9,12 @@ module WaxTasks
   class Collection
     attr_reader :name, :config, :ext, :search_fields,
                 :page_source, :metadata_source, :imagedata_source,
-                :iiif_derivative_source, :simple_derivative_source
+                :iiif_derivative_source, :simple_derivative_source,
+                :annotationdata_source
 
     include Collection::Metadata
     include Collection::Images
+    include Collection::Annotations
 
     IMAGE_DERIVATIVE_DIRECTORY = 'img/derivatives'
     DEFAULT_VARIANTS = { 'thumbnail' => 250, 'fullwidth' => 1140 }.freeze
@@ -27,6 +30,7 @@ module WaxTasks
       @metadata_source          = Utils.safe_join source, '_data', config.dig('metadata', 'source')
       @imagedata_source         = Utils.safe_join source, '_data', config.dig('images', 'source')
       @iiif_derivative_source   = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif'
+      @annotationdata_source    = Utils.safe_join source, '_data', config.dig('annotations', 'source')
       @simple_derivative_source = Utils.safe_join source, IMAGE_DERIVATIVE_DIRECTORY, 'simple'
       @search_fields            = %w[pid label thumbnail permalink collection]
       @image_variants           = image_variants

--- a/lib/wax_tasks/collection/annotations.rb
+++ b/lib/wax_tasks/collection/annotations.rb
@@ -8,6 +8,14 @@ module WaxTasks
     module Annotations
       #
       #
+      def get_source_type(source_path)
+        source_type = File.extname source_path # '.yaml' or '.json'
+        source_type = '.yaml' if source_type == '.yml'
+        source_type
+      end
+
+      #
+      #
       def annotations_from_annotationdata
         raise Error::MissingSource, "Cannot find annotation data source '#{@annotationdata_source}'" unless Dir.exist? @annotationdata_source
 
@@ -29,17 +37,26 @@ module WaxTasks
         bar = ProgressBar.new(annotations_from_annotationdata.length)
         bar.write
         annotations_from_annotationdata.map do |item|
-          item.annotations.each do |p|
-            path = "#{Utils.safe_join dir, File.basename(p, '.*')}.json"
+          item.annotations.each do |source_path|
+            dest_path = "#{Utils.safe_join dir, File.basename(source_path, '.*')}.json"
             # img/derivatives/iiif/annotation/test_collection_0_ocr_paragraph.json
-            FileUtils.mkdir_p File.dirname(path)
-            next if File.exist? path
+            FileUtils.mkdir_p File.dirname(dest_path)
+            next if File.exist? dest_path
 
-            # load yaml, write json
-            annotationlist = WaxTasks::AnnotationList.new(YAML.load_file(p, safe: true))
-            File.write(path, "---\nlayout: none\n---\n#{annotationlist.to_json}\n")
+            source_type = get_source_type source_path
+            case source_type
+            when '.yaml'
+              # load yaml, write json
+              annotationlist = WaxTasks::AnnotationList.new(SafeYAML.load_file(source_path))
+              File.write(dest_path, "---\nlayout: none\n---\n#{annotationlist.to_json}\n")
 
-            add_annotationlist_to_manifest(annotationlist, path)
+              # add_annotationlist_to_manifest(annotationlist, dest_path)
+            when '.json'
+              # TODO: handle json input - we assume it has uris in final jekyll-ready form
+              #  e.g. {{ '/' | absolute_url }}img/derivatives/iiif/annotation/recipebook_002_clippings.json
+
+              FileUtils.cp source_path, dest_path
+            end
           end
 
           # TODO: do we want to update the item-level csv?
@@ -52,37 +69,69 @@ module WaxTasks
 
       #
       #
-      def add_annotationlist_to_manifest(annotationlist, path)
-        # dir: img/derivatives/iiif/annotation
-        # annotationlist: <WaxTasks::AnnotationList>
-        # path: img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json
-byebug
+      def add_annotationlists_to_manifest(annotationlists)
         dir = 'img/derivatives/iiif/annotation'
         collection_dir_name = File.basename(@annotationdata_source)
-        byebug
+
         manifest_path = Utils.safe_join File.dirname(dir), collection_dir_name, 'manifest.json'
         manifest_front_matter, manifest_body = File.read(manifest_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
         manifest = JSON.parse(manifest_body)
-        canvas_id = "#{collection_dir_name}_#{annotationlist.name}"
+            byebug
+        annotationlists.each do |list_path|
+          source_type = get_source_type list_path
 
+          list = nil
+          canvas_id = nil
+
+          case source_type
+          when '.yaml'
+            list = SafeYAML.load_file(list_path)
+            canvas_id = "#{list['collection']}_#{list['canvas']}"
+          when '.json'
+            # TODO: encapsulate this yaml/json handling in a class
+            list_front_matter, list_body = File.read(list_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
+            list_yaml = YAML.load list_front_matter
+            list = JSON.parse(list_body)
+            canvas_id = "#{list_yaml['collection']}_#{list_yaml['canvas']}"
+          end
+          add_annotationlist_to_manifest(manifest, list, canvas_id)
+        end
+
+        # TODO : save only if changed
+        File.open(manifest_path, 'w') do |f|
+          f.write("#{manifest_front_matter}#{manifest.to_json}")
+        end
+
+      end
+
+      #
+      #
+      def add_annotationlist_to_manifest(manifest, annotationlist, canvas_id)
+        # dir: img/derivatives/iiif/annotation
+        # annotationlist: <WaxTasks::AnnotationList>
+        # annotationlist_uri: img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json
+        dir = 'img/derivatives/iiif/annotation'
+        annotationlist_uri = annotationlist['uri'] 
+        annotationlist_uri ||= annotationlist['@id']
+
+        # TODO: deal with multiple sequences, possibly containing same canvas (?)
         this_canvas = manifest['sequences'][0]['canvases'].find do |canvas|
           canvas['@id'] ==
             "{{ '/' | absolute_url }}img/derivatives/iiif/canvas/#{canvas_id}.json"
         end
-
-        # TODO: allow multiple annotationlists
+byebug
         # TODO: this has to run for annotationlists which are created as json in img/derivatives/iiif/annotations
-        if this_canvas.dig('otherContent', 0, '@id') ==
-           "{{ '/' | absolute_url }}#{path}"
+        this_canvas['otherContent'] ||= []
+
+        # TODO: remove entries for annotationlists that have been deleted
+
+        if this_canvas['otherContent'].find { |c| c['@id'] == annotationlist_uri }
           puts "AnnotationList #{canvas_id} already linked in Manifest"
         else
-          this_canvas['otherContent'] = [
-            {
-              '@id' => "{{ '/' | absolute_url }}#{path}",
-              '@type' => 'sc:AnnotationList'
-            }
-          ]
-          File.open(manifest_path, 'w') { |f| f.write("#{manifest_front_matter}#{manifest.to_json}") }
+          this_canvas['otherContent'] << {
+            '@id' => annotationlist_uri,
+            '@type' => 'sc:AnnotationList'
+          }
         end
       end
     end

--- a/lib/wax_tasks/collection/annotations.rb
+++ b/lib/wax_tasks/collection/annotations.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'byebug'
 #
 module WaxTasks
   #
@@ -76,7 +75,7 @@ module WaxTasks
         manifest_path = Utils.safe_join File.dirname(dir), collection_dir_name, 'manifest.json'
         manifest_front_matter, manifest_body = File.read(manifest_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
         manifest = JSON.parse(manifest_body)
-            byebug
+
         annotationlists.each do |list_path|
           source_type = get_source_type list_path
 
@@ -119,8 +118,7 @@ module WaxTasks
           canvas['@id'] ==
             "{{ '/' | absolute_url }}img/derivatives/iiif/canvas/#{canvas_id}.json"
         end
-byebug
-        # TODO: this has to run for annotationlists which are created as json in img/derivatives/iiif/annotations
+
         this_canvas['otherContent'] ||= []
 
         # TODO: remove entries for annotationlists that have been deleted

--- a/lib/wax_tasks/collection/annotations.rb
+++ b/lib/wax_tasks/collection/annotations.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+#
+module WaxTasks
+  #
+  class Collection
+    #
+    module Annotations
+      #
+      #
+      def annotations_from_annotationdata
+        raise Error::MissingSource, "Cannot find annotation data source '#{@annotationdata_source}'" unless Dir.exist? @annotationdata_source
+
+        records = records_from_metadata
+
+        Dir.glob(Utils.safe_join(@annotationdata_source, '*')).map do |path|
+          item = WaxTasks::Item.new(path, {})
+          item.record      = records.find { |r| r.pid == item.pid }
+          item.annotation_config = @config.dig 'annotations'
+          warn Rainbow("\nCould not find record in #{@annotationdata_source} for image item #{path}.\n").orange if item.record.nil?
+          item
+        end.compact
+      end
+
+      #
+      #
+      def write_annotations(dir)
+        puts Rainbow("Generating annotations for collection '#{@name}'").cyan
+        bar = ProgressBar.new(annotations_from_annotationdata.length)
+        bar.write
+        annotations_from_annotationdata.map do |item|
+          item.annotations.each do |p|
+            path = "#{Utils.safe_join dir, File.basename(p, '.*')}.json"
+            # img/derivatives/iiif/annotation/test_collection_0_ocr_paragraph.json
+            FileUtils.mkdir_p File.dirname(path)
+            next if File.exist? path
+
+            # load yaml, write json
+            annotationlist = WaxTasks::AnnotationList.new(YAML.load_file(p, safe: true))
+            File.write(path, "---\nlayout: none\n---\n#{annotationlist.to_json}\n")
+
+            # add to manifest
+            # TODO: this should be all done in wax_iiif, really, though
+            # the workflow sequencing that implies needs to be thought out
+
+            collection_dir_name = File.basename(@annotationdata_source)
+            manifest_path = Utils.safe_join File.dirname(dir), collection_dir_name, 'manifest.json'
+            raw_yaml, raw_json = File.read(manifest_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
+            manifest = JSON.parse(raw_json)
+            canvas_id = "#{collection_dir_name}_#{annotationlist.name}"
+
+            this_canvas = manifest['sequences'][0]['canvases'].find do |canvas|
+              canvas['@id'] ==
+                "{{ '/' | absolute_url }}img/derivatives/iiif/canvas/#{canvas_id}.json"
+            end
+
+            # TODO: allow multiple annotationlists
+
+            if this_canvas.dig('otherContent', 0, '@id') ==
+               "{{ '/' | absolute_url }}#{path}"
+              puts "AnnotationList #{canvas_id} already linked in Manifest"
+            else
+              this_canvas['otherContent'] = [
+                {
+                  '@id' => "{{ '/' | absolute_url }}#{path}",
+                  '@type' => 'sc:AnnotationList'
+                }
+              ]
+              File.open(manifest_path, 'w') { |f| f.write("#{raw_yaml}#{manifest.to_json}") }
+            end
+          end
+          # TODO: do we want to update the item-level csv?
+
+          bar.increment!
+          bar.write
+          item
+        end.flat_map(&:record).compact
+      end
+
+      #
+      #
+      def iiif_builder(dir)
+        build_opts = {
+          base_url: "{{ '/' | absolute_url }}#{dir}",
+          output_dir: dir,
+          collection_label: @name
+        }
+        WaxIiif::Builder.new(build_opts)
+      end
+
+      #
+      #
+      def add_font_matter_to_json_files(dir)
+        Dir.glob("#{dir}/**/*.json").each do |f|
+          Utils.add_yaml_front_matter_to_file f
+        end
+      end
+
+      #
+      #
+      def add_iiif_results_to_records(records, manifests)
+        records.map do |record|
+          next nil if record.nil?
+
+          manifest = manifests.find { |m| m.base_id == record.pid }
+          next record if manifest.nil?
+
+          json = JSON.parse manifest.to_json
+          @image_variants.each do |k, _v|
+            value = json.dig k
+            record.set k, "/#{Utils.content_clean(value)}" unless value.nil?
+          end
+
+          record.set 'manifest', "/#{Utils.content_clean(manifest.id)}"
+          record
+        end.compact
+      end
+
+      #
+      #
+      def write_iiif_derivatives(dir)
+        items     = items_from_imagedata
+        iiif_data = items.map(&:iiif_image_records).flatten
+        builder   = iiif_builder(dir)
+
+        builder.load iiif_data
+
+        puts Rainbow("Generating IIIF derivatives for collection '#{@name}'\nThis might take awhile.").cyan
+        builder.process_data
+        records = items.map(&:record).compact
+
+        add_font_matter_to_json_files dir
+        add_iiif_results_to_records records, builder.manifests
+      end
+    end
+  end
+end

--- a/lib/wax_tasks/collection/annotations.rb
+++ b/lib/wax_tasks/collection/annotations.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require 'byebug'
 #
 module WaxTasks
   #
@@ -39,7 +39,7 @@ module WaxTasks
             annotationlist = WaxTasks::AnnotationList.new(YAML.load_file(p, safe: true))
             File.write(path, "---\nlayout: none\n---\n#{annotationlist.to_json}\n")
 
-            add_annotationlist_to_manfest(dir, annotationlist, path)
+            add_annotationlist_to_manifest(annotationlist, path)
           end
 
           # TODO: do we want to update the item-level csv?
@@ -52,11 +52,17 @@ module WaxTasks
 
       #
       #
-      def add_annotationlist_to_manfest(dir, annotationlist, path)
+      def add_annotationlist_to_manifest(annotationlist, path)
+        # dir: img/derivatives/iiif/annotation
+        # annotationlist: <WaxTasks::AnnotationList>
+        # path: img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json
+byebug
+        dir = 'img/derivatives/iiif/annotation'
         collection_dir_name = File.basename(@annotationdata_source)
+        byebug
         manifest_path = Utils.safe_join File.dirname(dir), collection_dir_name, 'manifest.json'
-        raw_yaml, raw_json = File.read(manifest_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
-        manifest = JSON.parse(raw_json)
+        manifest_front_matter, manifest_body = File.read(manifest_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
+        manifest = JSON.parse(manifest_body)
         canvas_id = "#{collection_dir_name}_#{annotationlist.name}"
 
         this_canvas = manifest['sequences'][0]['canvases'].find do |canvas|
@@ -76,7 +82,7 @@ module WaxTasks
               '@type' => 'sc:AnnotationList'
             }
           ]
-          File.open(manifest_path, 'w') { |f| f.write("#{raw_yaml}#{manifest.to_json}") }
+          File.open(manifest_path, 'w') { |f| f.write("#{manifest_front_matter}#{manifest.to_json}") }
         end
       end
     end

--- a/lib/wax_tasks/item.rb
+++ b/lib/wax_tasks/item.rb
@@ -3,7 +3,7 @@
 module WaxTasks
   #
   class Item
-    attr_accessor :record, :iiif_config
+    attr_accessor :record, :iiif_config, :annotation_config
     attr_reader :pid
 
     #
@@ -58,6 +58,13 @@ module WaxTasks
     #
     def simple_derivatives
       @assets.map(&:simple_derivatives).flatten
+    end
+
+    #
+    #
+    def annotations
+      # TODO: integrate this with assets handling?
+      Dir.glob("#{@path}/*").sort
     end
 
     #

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -82,5 +82,18 @@ module WaxTasks
       collection.update_metadata records
       puts Rainbow("\nDone ✔").green
     end
+
+    #
+    #
+    def generate_annotations(name)
+      collection = @config.find_collection name
+
+      raise WaxTasks::Error::InvalidCollection if collection.nil?
+
+      output_dir = Utils.safe_join @config.source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif/annotation'
+      records = collection.write_annotations output_dir
+      collection.update_metadata records
+      puts Rainbow("\nDone ✔").green
+    end
   end
 end

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -92,6 +92,7 @@ module WaxTasks
 
       output_dir = Utils.safe_join @config.source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif/annotation'
       records = collection.write_annotations output_dir
+      byebug
       collection.update_metadata records
       puts Rainbow("\nDone ✔").green
     end

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -92,7 +92,6 @@ module WaxTasks
 
       output_dir = Utils.safe_join @config.source, IMAGE_DERIVATIVE_DIRECTORY, 'iiif/annotation'
       records = collection.write_annotations output_dir
-      byebug
       collection.update_metadata records
       puts Rainbow("\nDone ✔").green
     end

--- a/spec/sample_hocr/img_item_1.hocr
+++ b/spec/sample_hocr/img_item_1.hocr
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+ <head>
+  <title></title>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+  <meta name='ocr-system' content='tesseract 3.04.01' />
+  <meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par ocr_line ocrx_word'/>
+</head>
+<body>
+  <div class='ocr_page' id='page_1' title='image "img_item_1.jpg"; bbox 0 0 2600 1697; ppageno 0'>
+   <div class='ocr_carea' id='block_1_9' title="bbox 56 671 191 768">
+    <p class='ocr_par' dir='ltr' id='par_1_12' title="bbox 20 668 191 768">
+     <span class='ocr_line' id='line_1_37' title="bbox 60 671 183 726; baseline 0 -16; x_size 35; x_descenders 5; x_ascenders 11"><span class='ocrx_word' id='word_1_224' title='bbox 60 681 85 711; x_wconf 76' lang='eng' dir='ltr'><strong>If</strong></span> <span class='ocrx_word' id='word_1_225' title='bbox 99 671 147 710; x_wconf 79' lang='eng' dir='ltr'><strong>the</strong></span> <span class='ocrx_word' id='word_1_226' title='bbox 169 720 183 726; x_wconf 35' lang='eng'><strong>ax</strong></span> 
+     </span>
+     <span class='ocr_line' id='line_1_38' title="bbox 56 724 191 768; baseline -0.015 -12; x_size 36; x_descenders 7; x_ascenders 10"><span class='ocrx_word' id='word_1_227' title='bbox 56 725 135 760; x_wconf 70' lang='eng' dir='ltr'><strong>falls</strong></span> <span class='ocrx_word' id='word_1_228' title='bbox 149 724 191 768; x_wconf 23' lang='eng' dir='ltr'><strong>the</strong></span> 
+     </span>
+    </p>
+   </div>
+  </div>
+ </body>
+</html>

--- a/spec/sample_hocr/manifest.json
+++ b/spec/sample_hocr/manifest.json
@@ -1,0 +1,49 @@
+---
+layout: none
+---
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "{{ '/' | absolute_url }}img/derivatives/iiif/test_collection/manifest.json",
+  "@type": "sc:Manifest",
+  "label": "test_collection",
+  "thumbnail": "{{ '/' | absolute_url }}img/derivatives/iiif/images/test_collection_img_item_1/full/250,/0/default.jpg",
+  "viewingDirection": "left-to-right",
+  "viewingHint": "individuals",
+  "sequences": [
+    {
+      "@id": "{{ '/' | absolute_url }}img/derivatives/iiif/sequence/test_collection_img_item_1.json",
+      "@type": "sc:Sequence",
+      "canvases": [
+        {
+          "@type": "sc:Canvas",
+          "@id": "{{ '/' | absolute_url }}img/derivatives/iiif/canvas/test_collection_img_item_1.json",
+          "label": "Page 1",
+          "width": 2600,
+          "height": 1697,
+          "thumbnail": "{{ '/' | absolute_url }}img/derivatives/iiif/images/test_collection_img_item_1/full/250,/0/default.jpg",
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "@id": "{{ '/' | absolute_url }}img/derivatives/iiif/annotation/test_collection_img_item_1.json",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "{{ '/' | absolute_url }}img/derivatives/iiif/images/test_collection_img_item_1/full/full/0/default.jpg",
+                "@type": "dcterms:Image",
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "{{ '/' | absolute_url }}img/derivatives/iiif/images/test_collection_img_item_1",
+                  "profile": "http://iiif.io/api/image/2/level0.json"
+                },
+                "width": 2600,
+                "height": 1697
+              },
+              "on": "{{ '/' | absolute_url }}img/derivatives/iiif/canvas/test_collection_img_item_1.json"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "full": "{{ '/' | absolute_url }}img/derivatives/iiif/images/test_collection_img_item_1/full/full/0/default.jpg"
+}

--- a/spec/sample_hocr/test_collection_img_item_1_ocr_paragraph.yaml
+++ b/spec/sample_hocr/test_collection_img_item_1_ocr_paragraph.yaml
@@ -1,7 +1,7 @@
 ---
 uri: "{{ '/' | absolute_url }}img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json"
 collection: test_collection
-id: 'img_item_1'
+canvas: 'img_item_1'
 label: test_collection_img_item_1_ocr_paragraph
 target: "{{ '/' | absolute_url }}img/derivatives/iiif/canvas/test_collection_img_item_1.json"
 resources:

--- a/spec/sample_hocr/test_collection_img_item_1_ocr_paragraph.yaml
+++ b/spec/sample_hocr/test_collection_img_item_1_ocr_paragraph.yaml
@@ -1,6 +1,8 @@
 ---
+uri: "{{ '/' | absolute_url }}img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json"
+collection: test_collection
 id: 'img_item_1'
-label: img_item_1-annotation-list-paragraph
+label: test_collection_img_item_1_ocr_paragraph
 target: "{{ '/' | absolute_url }}img/derivatives/iiif/canvas/test_collection_img_item_1.json"
 resources:
 - xywh: '20,668,171,100'

--- a/spec/sample_hocr/test_collection_img_item_1_ocr_paragraph.yaml
+++ b/spec/sample_hocr/test_collection_img_item_1_ocr_paragraph.yaml
@@ -1,0 +1,7 @@
+---
+id: 'img_item_1'
+label: img_item_1-annotation-list-paragraph
+target: "{{ '/' | absolute_url }}img/derivatives/iiif/canvas/test_collection_img_item_1.json"
+resources:
+- xywh: '20,668,171,100'
+  chars: If the ax falls the

--- a/spec/sample_site/_config.yml
+++ b/spec/sample_site/_config.yml
@@ -10,6 +10,8 @@ collections:
       source: valid.csv
     images:
       source: 'images/test_collection'
+    annotations:
+      source: 'annotations/test_collection'
   json_collection:
     layout: default.html
     metadata:

--- a/spec/wax_tasks/annotations_spec.rb
+++ b/spec/wax_tasks/annotations_spec.rb
@@ -3,25 +3,36 @@
 describe WaxTasks::AnnotationList do
   include_context 'shared'
 
-  include_context 'shared'
-  let(:config)          { site_from_config_file.config }
-  let(:source)          { config.source }
-  let(:collections_dir) { config.collections_dir }
-
   before(:all) do
     Test.reset
   end
 
   #
   # ===================================================
-  # ANNOTATION.NEW
+  # ANNOTATION.UPDATEMANIFEST
   # ===================================================
   #
-  describe '#new' do
-    context 'generates json' do
-      it 'works' do
-      byebug
-          expect { WaxTasks::AnnotationList.new({}) }.not_to raise_error
+  describe '#updatemanifest' do
+    context 'updates manifest' do
+      it 'updates manifest' do
+        FileUtils.mkdir_p "#{BUILD}/img/derivatives/iiif/test_collection/"
+        FileUtils.cp Dir.glob("#{ROOT}/spec/sample_hocr/manifest.json"), "#{BUILD}/img/derivatives/iiif/test_collection/"
+        FileUtils.mkdir_p "#{BUILD}/_data/annotations/test_collection/dir_imgs_item/"
+        FileUtils.cp Dir.glob("#{ROOT}/spec/sample_hocr/*.yaml"), "#{BUILD}/_data/annotations/test_collection/dir_imgs_item/"
+
+        config = WaxTasks::Config.new(config || WaxTasks.config_from_file)
+        collection = config.find_collection 'csv_collection'
+
+        collection.add_annotationlists_to_manifest(
+          Dir.glob("#{BUILD}/_data/annotations/test_collection/dir_imgs_item/*.{yaml,yml,json}").sort
+        )
+
+        manifest_path = "#{BUILD}/img/derivatives/iiif/test_collection/manifest.json"
+        raw_yaml, raw_json = File.read(manifest_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
+        manifest = JSON.parse(raw_json)
+
+        expect(manifest['sequences'][0]['canvases'][0]['otherContent']).not_to be_nil
+        expect(manifest['sequences'][0]['canvases'][0]['otherContent'][0]['@id']).to eq("{{ '/' | absolute_url }}img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json")
       end
     end
   end

--- a/spec/wax_tasks/annotations_spec.rb
+++ b/spec/wax_tasks/annotations_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe WaxTasks::AnnotationList do
+  include_context 'shared'
+
+  include_context 'shared'
+  let(:config)          { site_from_config_file.config }
+  let(:source)          { config.source }
+  let(:collections_dir) { config.collections_dir }
+
+  before(:all) do
+    Test.reset
+  end
+
+  #
+  # ===================================================
+  # ANNOTATION.NEW
+  # ===================================================
+  #
+  describe '#new' do
+    context 'generates json' do
+      it 'works' do
+      byebug
+          expect { WaxTasks::AnnotationList.new({}) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/wax_tasks/hocr_spec.rb
+++ b/spec/wax_tasks/hocr_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/tasks/import/hocr.rb'
+
+describe HocrOpenAnnotationCreator do
+  include_context 'shared'
+
+  before(:all) do
+    Test.reset
+  end
+
+  #
+  # ===================================================
+  # HocrOpenAnnotationCreator.NEW
+  # ===================================================
+  #
+  describe '#new' do
+    include_context 'shared'
+
+    context 'parses hocr file not to raise error' do
+      it 'runs without errors' do
+        expect { HocrOpenAnnotationCreator.new({
+          hocr_path: "#{ROOT}/spec/sample_hocr/img_item_1.hocr",
+          collection: 'test_collection',
+          canvas: 'img_item_1',
+          granularity: 'paragraph'
+        }) }.not_to raise_error
+      end
+	  end
+  end
+
+  describe '#save' do
+    include_context 'shared'
+
+    context 'hocr yaml file' do
+      hocr = HocrOpenAnnotationCreator.new({
+        hocr_path: "#{ROOT}/spec/sample_hocr/img_item_1.hocr",
+        collection: 'test_collection',
+        canvas: 'img_item_1',
+        granularity: 'paragraph'
+      })
+
+      it 'captures chars correctly' do
+        expect(hocr.resources.first[:resource][:chars]).to eq('If the ax falls the')
+      end
+      
+      it 'captures target correctly' do
+        expect(hocr.resources.first[:on]).to eq("{{ '/' | absolute_url }}img/derivatives/iiif/canvas/test_collection_img_item_1.json#xywh=20,668,171,100")
+      end
+	  end
+  end
+
+end

--- a/spec/wax_tasks/site_spec.rb
+++ b/spec/wax_tasks/site_spec.rb
@@ -283,8 +283,6 @@ describe WaxTasks::Site do
     before(:example) do
       FileUtils.mkdir_p "#{BUILD}/_data/annotations/test_collection/dir_imgs_item/"
       FileUtils.cp Dir.glob("#{ROOT}/spec/sample_hocr/*.yaml"), "#{BUILD}/_data/annotations/test_collection/dir_imgs_item/"
-      FileUtils.mkdir_p "#{BUILD}/img/derivatives/iiif/test_collection/"
-      FileUtils.cp Dir.glob("#{ROOT}/spec/sample_hocr/manifest.json"), "#{BUILD}/img/derivatives/iiif/test_collection/"
     end
 
     # TODO: mock or stub the annotation and manifest files, break up this block

--- a/spec/wax_tasks/site_spec.rb
+++ b/spec/wax_tasks/site_spec.rb
@@ -290,16 +290,18 @@ describe WaxTasks::Site do
     # TODO: mock or stub the annotation and manifest files, break up this block
     context 'when generates sample annotationlist' do
       it 'generates annotationlist and updates manifest' do
- 
+ byebug
         expect { site_from_config_file.generate_annotations('csv_collection') }.not_to raise_error
-
+byebug
         json_file = "#{BUILD}/img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json"
         expect(File).to exist(json_file)
+
         raw_yaml, raw_json = File.read(json_file).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
         annotation = JSON.parse(raw_json)['resources'].first
         expect(annotation['on']).to eq("{{ '/' | absolute_url }}img/derivatives/iiif/canvas/test_collection_img_item_1.json#xywh=20,668,171,100")
         expect(annotation['resource']['chars']).to eq('If the ax falls the')
 
+        # link to annotation list has been added to manifest
         manifest_path = "#{BUILD}/img/derivatives/iiif/test_collection/manifest.json"
         raw_yaml, raw_json = File.read(manifest_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
         manifest = JSON.parse(raw_json)

--- a/spec/wax_tasks/site_spec.rb
+++ b/spec/wax_tasks/site_spec.rb
@@ -280,7 +280,7 @@ describe WaxTasks::Site do
   #
 
   describe '#generate_annotationlists' do
-    before(:each) do
+    before(:example) do
       FileUtils.mkdir_p "#{BUILD}/_data/annotations/test_collection/dir_imgs_item/"
       FileUtils.cp Dir.glob("#{ROOT}/spec/sample_hocr/*.yaml"), "#{BUILD}/_data/annotations/test_collection/dir_imgs_item/"
       FileUtils.mkdir_p "#{BUILD}/img/derivatives/iiif/test_collection/"
@@ -289,28 +289,21 @@ describe WaxTasks::Site do
 
     # TODO: mock or stub the annotation and manifest files, break up this block
     context 'when generates sample annotationlist' do
-      it 'generates annotationlist and updates manifest' do
- byebug
+      it 'runs without error' do
         expect { site_from_config_file.generate_annotations('csv_collection') }.not_to raise_error
-byebug
+      end
+
+      it 'generates annotationlist' do
         json_file = "#{BUILD}/img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json"
         expect(File).to exist(json_file)
-
         raw_yaml, raw_json = File.read(json_file).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
         annotation = JSON.parse(raw_json)['resources'].first
         expect(annotation['on']).to eq("{{ '/' | absolute_url }}img/derivatives/iiif/canvas/test_collection_img_item_1.json#xywh=20,668,171,100")
         expect(annotation['resource']['chars']).to eq('If the ax falls the')
-
-        # link to annotation list has been added to manifest
-        manifest_path = "#{BUILD}/img/derivatives/iiif/test_collection/manifest.json"
-        raw_yaml, raw_json = File.read(manifest_path).match(/(---\n.+?\n---\n)(.*)/m)[1..2]
-        manifest = JSON.parse(raw_json)
-        expect(manifest['sequences'][0]['canvases'][0]['otherContent']).not_to be_nil
-        expect(manifest['sequences'][0]['canvases'][0]['otherContent'][0]['@id']).to eq("{{ '/' | absolute_url }}img/derivatives/iiif/annotation/test_collection_img_item_1_ocr_paragraph.json")
       end
     end
 
-    after(:each) do
+    after(:example) do
       FileUtils.rm Dir.glob("#{BUILD}/_data/annotations/test_collection/dir_imgs_item/*.yaml")
       FileUtils.rm Dir.glob("#{BUILD}/img/derivatives/iiif/test_collection/manifest.json")
     end


### PR DESCRIPTION
This PR adds a basic framework for creating and deploying annotation lists in Wax. The purpose is to make Wax a more full-featured IIIF publishing platform for small but intensively curated digital scholarship projects.

I will add instructions for use to the README.md. The gist is this:

- add annotation lists in ```_data/annotations```. They may be preformed IIIF annotation lists (following Presentation API 2.1.1), or simple YAML files that indicate collection, canvas, xywh, and text.
- run ```bundle exec rake wax:annotations <collection>``` to generate the annotation list in ```img/derivatives/iiif/annotations/<collection>```
- run ```bundle exec rake wax:updatemanifest <collection>``` to add ```otherContent``` links to the appropriate canvas in the collection manifest

There are a couple of specs for the hocr import process and the manifest update process.

The ```updatemanifest``` task must be run after the manifest is created. Both tasks could be merged into the main Wax IIIF derivatives tasks or kept as separate tasks. If we prefer to keep ```wax_tasks``` simple, all of this could be put in a separate ```wax_annotations``` gem for optional inclusion.

To demonstrate the YAML-based annotation format there is a task, ```wax:import:hocr```, which accepts an external HOCR file and generates a YAML file in ```_data/annotations``` (adapted from [Ocracoke](https://github.com/NCSU-Libraries/ocracoke/blob/master/app/processing_helpers/hocr_open_annotation_creator.rb)). We can add other submodules to ```wax:import``` as we identify other useful sources of annotations, possibly including:

- other OCR formats
- page zoning markup in OCR files such as METS/ALTO (e.g. newspaper articles)
- annotations from external annotation servers that we want to embed in the Wax site directly
- browser local storage, as used by e.g. Mirador when creating annotations (maybe based on [pbinkley/iiif-firefox-annotation-extract](https://github.com/pbinkley/iiif-firefox-annotation-extract)
- annotations created by other IIIF tools such as [FromThePage](https://fromthepage.com/)
- bibliographic metadata (MARC, MODS, Zotero export, etc.)
- etc.

Some TODOs:

- integrate Mirador 3 into ```wax_theme```, with a good set of default behaviors to display/hide different annotation lists
- provide options to index annotations and make them searchable with Lunr
- a task to generate annotation-level Jekyll pages, populated from the annotation data - e.g. the recipes in my recipe book demo project. The annotation URI can be the URL of the corresponding page.
- move from Open Annotations to Web Annotations to keep up with IIIF 3, probably in conjunction with upgrading the rest of Wax (including ```wax_iiif``` which will be no small job)
- consider moving all the annotation and manifest work into ```wax_iiif```
- I think I've made the collection/item handling unnecessarily messy
- where appropriate populate other LOD sets with data from annotations, for publication in the Jekyll site