### PR TITLE
fix typo in description of simple derivatives task

### DIFF
--- a/lib/tasks/derivatives_simple.rake
+++ b/lib/tasks/derivatives_simple.rake
@@ -4,7 +4,7 @@ require 'wax_tasks'
 
 namespace :wax do
   namespace :derivatives do
-    desc 'generate iiif derivatives from local image files'
+    desc 'generate simple derivatives from local image files'
     task :simple do
       args = ARGV.drop(1).each { |a| task a.to_sym }
       args.reject! { |a| a.start_with? '-' }


### PR DESCRIPTION
Hi, just a tiny change for a typo I noticed as a Wax user when I ran `bundle exec rake --tasks`.

In the simple derivatives task, the `desc` previously read "generate **iiif** derivatives from local image files". I updated it to "generate **simple** derivatives from local image files".

Thank you!